### PR TITLE
fix sequence orientation in maf

### DIFF
--- a/src/pbsim.cpp
+++ b/src/pbsim.cpp
@@ -1810,11 +1810,6 @@ int simulate_by_sample() {
         mut.maf_seq[maf_offset] = '\0';
         mut.maf_ref_seq[maf_offset] = '\0';
 
-        if (mut.seq_strand == '-') {
-          revcomp(mut.maf_seq);
-          revcomp(mut.maf_ref_seq);
-        }
-
         mut.seq_left = mut.offset + 1;
         mut.seq_right = mut.offset + ref_offset;
 
@@ -2259,11 +2254,6 @@ int simulate_by_qshmm() {
       mut.read_seq[read_offset] = '\0';
       mut.maf_seq[maf_offset] = '\0';
       mut.maf_ref_seq[maf_offset] = '\0';
-
-      if (mut.seq_strand == '-') {
-        revcomp(mut.maf_seq);
-        revcomp(mut.maf_ref_seq);
-      }
 
       len = strlen(mut.read_seq);
       sim.res_len_total += len;
@@ -2895,11 +2885,6 @@ int simulate_by_qshmm_trans() {
           mut.read_seq[read_offset] = '\0';
           mut.maf_seq[maf_offset] = '\0';
           mut.maf_ref_seq[maf_offset] = '\0';
-
-          if (mut.seq_strand == '-') {
-            revcomp(mut.maf_seq);
-            revcomp(mut.maf_ref_seq);
-          }
 
           len = strlen(mut.read_seq);
           sim.res_len_total += len;
@@ -3953,11 +3938,6 @@ int simulate_by_errhmm() {
       mut.maf_seq[maf_offset] = '\0';
       mut.maf_ref_seq[maf_offset] = '\0';
 
-      if (mut.seq_strand == '-') {
-        revcomp(mut.maf_seq);
-        revcomp(mut.maf_ref_seq);
-      }
-
       len = strlen(mut.read_seq);
       sim.res_len_total += len;
 
@@ -4647,11 +4627,6 @@ int simulate_by_errhmm_trans() {
           mut.read_seq[read_offset] = '\0';
           mut.maf_seq[maf_offset] = '\0';
           mut.maf_ref_seq[maf_offset] = '\0';
-
-          if (mut.seq_strand == '-') {
-            revcomp(mut.maf_seq);
-            revcomp(mut.maf_ref_seq);
-          }
 
           len = strlen(mut.read_seq);
           sim.res_len_total += len;


### PR DESCRIPTION
I found sequences in generated maf are reversed for `-` reads. It looks the current code flips sequences when `mut.seq_strand == '-'`, which is not needed as the `maf_seq` and `read_seq` are already in their correct direction and we compose maf alignment records with reference-side sequences in `+` direction.